### PR TITLE
Update start.sh

### DIFF
--- a/ganglia/start.sh
+++ b/ganglia/start.sh
@@ -71,7 +71,7 @@ chown -R nobody:nobody /var/lib/ganglia/rrds
 
 service httpd start
 
-[[ -n $WITH_GMOND ]] && gmond -p /var/run/gmond.pid
+[[ -n $WITH_GMOND ]] && gmond
 
 # last command must stay in foreground, this is the main reason for -d 1
-gmetad -d 1 -p /var/run/gmetad.pid
+gmetad -d 1


### PR DESCRIPTION
Got rid of the pid files. 
A container restart (using --with-gmond) did not restart gmond. I suspect that the gmetad start up is killing the gmond that was just started because the 'old' pid of the gmetad is the same as the new pid of gmond. 

Removing the pid file stuff makes the container start correctly